### PR TITLE
fix: guard AdminPHAL validator.validate so a raising validator skips the plugin

### DIFF
--- a/ovos_PHAL/admin.py
+++ b/ovos_PHAL/admin.py
@@ -55,7 +55,11 @@ class AdminPHAL(PHAL):
             if not enabled:
                 continue  # require explicit enabling by user
             if hasattr(plug, "validator"):
-                enabled = plug.validator.validate(config)
+                try:
+                    enabled = plug.validator.validate(config)
+                except Exception:
+                    LOG.exception(f"Validator failed for PHAL plugin: {name}")
+                    continue
 
             if enabled:
                 try:


### PR DESCRIPTION
Closes #92.

`PHAL.load_plugins` (service.py:80-85) wraps `validator.validate()` in try/except; `AdminPHAL.load_plugins` (admin.py:58) did not, so a raising validator aborted loading of all remaining admin plugins. This mirrors the service.py guard (log + skip the plugin).

Found during a source-validation pass of the OVOS Technical Manual.