### PR TITLE
feat: run ServiceInstaller so PHAL plugins install into the PHAL env over the bus

### DIFF
--- a/ovos_PHAL/service.py
+++ b/ovos_PHAL/service.py
@@ -3,6 +3,7 @@ from ovos_config import Configuration
 from ovos_utils.log import LOG
 from ovos_bus_client.client import MessageBusClient
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap
+from ovos_utils.skill_installer import ServiceInstaller
 
 
 def on_ready():
@@ -63,6 +64,15 @@ class PHAL:
             self.admin_config = {}
         self.drivers = {}
         self.status.bind(self.bus)
+        # The admin PHAL is a *separate process* (usually root) that owns the
+        # admin plugins, so it installs into its own environment under a
+        # distinct topic. AdminPHAL passes skill_id="PHAL.admin"; the plain
+        # PHAL daemon uses "PHAL". Route each to its own installer service so a
+        # wifi/system (admin) plugin lands in the root env and a user plugin in
+        # the user env.
+        installer_service = "ovos_PHAL_admin" if self.skill_id == "PHAL.admin" \
+            else "ovos_PHAL"
+        self.installer = ServiceInstaller(self.bus, service_name=installer_service)
 
     def load_plugins(self):
         for name, plug in find_phal_plugins().items():
@@ -104,4 +114,6 @@ class PHAL:
             self.status.set_error(e)
 
     def shutdown(self):
+        if getattr(self, "installer", None):
+            self.installer.shutdown()
         self.status.set_stopping()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 keywords = ["ovos", "phal", "plugin"]
 dependencies = [
-    "ovos-utils>=0.0.38,<1.0.0",
+    "ovos-utils>=0.8.5,<1.0.0",
     "ovos_bus_client>=0.0.8,<3.0.0",
     "ovos-config>=0.0.12,<3.0.0",
     "ovos-plugin-manager>=0.0.25,<3.0.0"


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

## What

Run `ovos_utils.skill_installer.ServiceInstaller` in the PHAL service so PHAL
installs plugins into its own environment over the message bus, replying on the
base `ovos.pip.install.complete` / `.failed` topics.

## Two processes, two topics

The **admin PHAL is a separate process** (`AdminPHAL`, `skill_id="PHAL.admin"`,
usually running as root) that owns the admin plugins — even though it ships in
this same repo. A wifi-setup or system/power plugin must be installed into the
**root** environment, a regular plugin into the **user** environment. So the two
processes register **distinct** targeted topics, derived from `skill_id`:

| Process | `skill_id` | targeted topic |
|---|---|---|
| plain PHAL daemon | `PHAL` | `ovos.pip.install.ovos_PHAL` |
| admin PHAL daemon | `PHAL.admin` | `ovos.pip.install.ovos_PHAL_admin` |

Both also answer the broadcast `ovos.pip.install` / `.uninstall`. The
[ovos-webui](https://github.com/OpenVoiceOS/ovos-webui) plugin browser routes
admin capability plugins (network/wifi, power/system) to `ovos_PHAL_admin` and
ordinary PHAL plugins to `ovos_PHAL`.

## service_name convention

Module/process names with underscores, following `ServiceInstaller`'s own
documented convention (its docstring lists `ovos_audio`, `ovos_gui`,
`ovos_core`, `ovos_messagebus`). Companion PRs: ovos-audio, ovos-gui,
ovos-dinkum-listener, ovos-core.

## Safety

Gated by the existing `skills.installer.allow_pip` config — off by default.
Cleanly unregistered on shutdown.

## Changes

- `ovos_PHAL/service.py`: instantiate `ServiceInstaller` with a `skill_id`-derived
  `service_name` (`ovos_PHAL` vs `ovos_PHAL_admin`); shut it down on stop.
- `pyproject.toml`: bump `ovos-utils` floor to `>=0.8.5`.
